### PR TITLE
Don't overwrite the table URL on table load

### DIFF
--- a/app/assets/javascripts/osom-tables.js
+++ b/app/assets/javascripts/osom-tables.js
@@ -66,7 +66,11 @@
 
     $.ajax(url, {
       success: function(new_content) {
-        container.replaceWith(new_content);
+        var new_container = $(new_content);
+        container.replaceWith(new_container);
+
+        var actual_table = new_container.find('table');
+        actual_table.data('url', url);
       },
       complete: function() {
         container.removeClass('loading');


### PR DESCRIPTION
This allows the column sorting to work without overwriting the whole query string on every sort.