### PR TITLE
Allow use of push with multiple tables on a single page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Ajax tables engine that respects MVC and goes well with the rails way.
 
 You can find a simple demo-app [over here](https://github.com/MadRabbit/osom-tables-app)
 
-
 ## Simple Setup
 
 Add this gem to your `Gemfile`
@@ -65,7 +64,6 @@ And finally, add the assets to your `application.js` and `application.css` files
 
 And you're good to go!
 
-
 ## Adding Sorting
 
 OsomTables don't enforce any sort of dealing with the sorting, just use your standard scopes.
@@ -115,6 +113,14 @@ end
 
 And don't forget to enjoy the awesomeness of easily unit-testable code!
 
+## Table Reuse
+
+By default `osom-tables` will use your current url as the url to fetch the table data. If you wish to reuse the `_table` partial from another view/controller, you must specify the `url: resource_path` option to ensure the table data is sourced correctly.
+
+```haml
+= osom_tables_for @things, url: things_path do |t|
+  ...
+```
 
 ## HTML5 Push State
 
@@ -122,24 +128,16 @@ OsomTables can easily hook you up with the html5 push-state goodness.
 Yes, it's just like `pjax` (whoever come up with this name) only better
 coz it renders only what needs to be rendered.
 
-To switch push state on, just pass the `push: true` option with your table
+To switch push state on, just pass the `push: true` option with your table. You must also use `async: true`.
 
 ```haml
-= osom_tables_for @things, push: true do |t|
+= osom_tables_for @things, async: true, push: true do |t|
   ...
 ```
 
+## HTML5 Push State and Filters
 
-## Custom Urls
-
-By default `osom-tables` will use your current url as the base one. But,
-in case you would like to reuse the `_table` partial, in different locations,
-you do so, but specifying the `url: smth_path` option with your tables
-
-```haml
-= osom_tables_for @things, url: other_things_path do |t|
-  ...
-```
+When using html5 push-state with a filterbar like the one used in AVETARS, do not use `async: true` as the filterbar will handle the loading of the table data after adding filter parameters to the query string.
 
 ## License & Copyright
 

--- a/lib/osom_tables.rb
+++ b/lib/osom_tables.rb
@@ -1,3 +1,3 @@
 module OsomTables
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end

--- a/lib/osom_tables/helper.rb
+++ b/lib/osom_tables/helper.rb
@@ -9,7 +9,7 @@ module OsomTables::Helper
     options  = args.extract_options!
     items    = args.first || []
     push     = options[:push] == true and options.delete(:push)
-    url      = options[:url]   || request.fullpath and options.delete(:url)
+    url      = options[:url]   || request.path and options.delete(:url)
     search   = options[:search] == true and options.delete(:search)
     paginate = options[:paginate] || {} and options.delete(:paginate)
     url      = url.gsub(/(\?|&)osom_tables_cache_killa=[^&]*?/, '')
@@ -17,6 +17,7 @@ module OsomTables::Helper
     # Allow the table to be loaded asynchronously
     if options[:async]
       options[:class] ||= []
+      options[:class] = options[:class].split(' ') if options[:class].is_a?(String)
       options[:class] << 'async'
     end
 
@@ -68,7 +69,7 @@ module OsomTables::Helper
 
     def head(&block)
       inner, has_tr = capture_tr { yield }
-      
+
       head_row = if has_tr
         inner
       else


### PR DESCRIPTION
https://jobready.atlassian.net/browse/AV-2642
https://jobready.atlassian.net/browse/AV-2606

To support multiple tables with push state, query parameters for each table are wrapped inside an osom-tables hash like:
pathname + '?' + $.param({ 'osom-tables' => { 'table_1_id' => 'table_1_url', ... } })

