### PR TITLE
[AV-3512] Only apply blur css filter to thead and tbody of table

### DIFF
--- a/app/assets/stylesheets/osom-tables.css.scss
+++ b/app/assets/stylesheets/osom-tables.css.scss
@@ -82,7 +82,7 @@
 
   &.loading, &.empty {
     table {
-      th, td {
+      thead, tbody {
         -webkit-filter: blur(1.5px);
         -moz-filter:    blur(1.5px);
         -ms-filter:     blur(1.5px);

--- a/lib/osom_tables.rb
+++ b/lib/osom_tables.rb
@@ -1,3 +1,3 @@
 module OsomTables
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
https://jobready.atlassian.net/browse/AV-3512

The css blur filter is used solely to visually indicate that the table is reloading. It is currently applied to all `td` and `th` elements. This is unnecessary and leads to performance issues in rendering particularly on mobile devices since the filter is applied for each table cell. If you have a large table of 50 rows with 10 columns, that's 500 blurs! The qualifications index in AVETARS fails to load because of this as it hits a device limit on memory/time-to-render.

The solution is to only apply the blur filter once to the entire table. Unfortunately, the spinner is inserted into the table's caption element so if we apply the blur at the table level, it will also blur the spinner and that doesn't look nice. As a compromise, we can blur the `thead` and `tbody` elements instead. This keeps the spinner looking nice and decreases the blur filter rendering from many to just 2. As a result, the qualifications index on AVETARS now loads.