### PR TITLE
Add checkboxes to datatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ And finally, add the assets to your `application.js` and `application.css` files
 
 And you're good to go!
 
+## Adding Checkbox
+
+OsomTables offer show_checkbox setting to enable checkboxes on datatable
+
+```haml
+= osom_table_for @things, show_checkbox: true do |t|
+
+  = t.head do
+    %th Name
+    %th Size
+
+  = t.body do |thing|
+    %td= thing.name
+    %td= thing.size
+```
+
+The checked checkbox stage is able to be saved when you navigate through pages.
+
 ## Adding Sorting
 
 OsomTables don't enforce any sort of dealing with the sorting, just use your standard scopes.

--- a/app/assets/javascripts/osom-tables.js
+++ b/app/assets/javascripts/osom-tables.js
@@ -23,7 +23,7 @@
   $(document).on('click', '.osom-table table th.mark > input[type="checkbox"]', mark_an_item_as_checked);
 
   $(document).on('click', '.osom-table table td.mark > input[type="checkbox"]', function() {
-    return save_checkboxes($(this).closest('.osom-table'));
+    return store_checked_ids_in_data_attribute($(this).closest('.osom-table'));
   });
 
   /* Load async tables */

--- a/lib/osom_tables.rb
+++ b/lib/osom_tables.rb
@@ -1,3 +1,3 @@
 module OsomTables
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end


### PR DESCRIPTION
<img width="1208" alt="screen shot 2016-11-01 at 8 11 47 pm" src="https://cloud.githubusercontent.com/assets/1320349/19891017/b2bfa008-a070-11e6-9f61-2a1686ff2873.png">

- Now you dont need to add a checkbox column on each table partial file, what you need to do is to set the `show_checkbox: true` setting when declaring osom-table then checkboxes will automatically showed on your table.

```ruby
= osom_table_for  items, show_checkbox: true, .... do
  = t.head do
     ....
  = t.body do |item|
     ....


```
