### PR TITLE
Trigger bug fix

### DIFF
--- a/app/assets/javascripts/osom-tables.js
+++ b/app/assets/javascripts/osom-tables.js
@@ -107,6 +107,7 @@
       },
       complete: function() {
         container.removeClass('loading');
+        actual_table  = container.find('table');
         actual_table.trigger('osom-table:loaded');
       }
     });


### PR DESCRIPTION
The bug is 'osom-table:loaded' event never be triggered because we changed the context of Div in ajax success function, the old table was replaced by the new table, we have to find this new table again.