### PR TITLE
NEP-1073: Pagination on tabs - head repeats when paginating

### DIFF
--- a/app/assets/javascripts/osom-tables.js
+++ b/app/assets/javascripts/osom-tables.js
@@ -150,8 +150,8 @@
 
   // Callback for successful ajax load of table data
   function table_load_success(container, new_content, url) {
-    var new_container = $(new_content);
-    container.html($(new_content).children());
+    var new_container = $('<div class="osom-table ">').append($(new_content).filter('div.osom-table'));
+    container.html(new_container);
 
     var actual_table = new_container.find('table');
     actual_table.data('url', url);

--- a/lib/osom_tables.rb
+++ b/lib/osom_tables.rb
@@ -1,3 +1,3 @@
 module OsomTables
-  VERSION = '3.1.3'
+  VERSION = '3.1.4'
 end


### PR DESCRIPTION
Per https://jobready.atlassian.net/browse/NEP-1073

Fix to prevent elements outside of `<div class="osom-table">` from being re-rendered on pagination (see screenshot).

NB `.append/.filter` combo in use, as `.find` won't work due to structure of the `new_content` being returned (happy to be proved wrong here).

![screen shot 2015-07-20 at 4 49 10 pm](https://user-images.githubusercontent.com/24996538/27562418-9e9c25f0-5b0b-11e7-8238-c2578d35b4df.png)
