### PR TITLE
Add Record Tags helper

### DIFF
--- a/lib/osom_tables.rb
+++ b/lib/osom_tables.rb
@@ -1,3 +1,3 @@
 module OsomTables
-  VERSION = '3.2.1'
+  VERSION = '3.2.2'
 end

--- a/lib/osom_tables/helper.rb
+++ b/lib/osom_tables/helper.rb
@@ -1,6 +1,7 @@
 require 'osom_tables/record_tag_helper'
 
 module OsomTables::Helper
+  include OsomTables::RecordTagHelper
   # @param [Object] items items to be displayed, not needed if the async option is set
   # @param [Hash] options
   # @option opts [Boolean] :async Load the table content asynchronously on dom ready

--- a/lib/osom_tables/helper.rb
+++ b/lib/osom_tables/helper.rb
@@ -1,5 +1,6 @@
-module OsomTables::Helper
+require 'osom_tables/record_tag_helper'
 
+module OsomTables::Helper
   # @param [Object] items items to be displayed, not needed if the async option is set
   # @param [Hash] options
   # @option opts [Boolean] :async Load the table content asynchronously on dom ready

--- a/lib/osom_tables/railtie.rb
+++ b/lib/osom_tables/railtie.rb
@@ -5,7 +5,7 @@ class OsomTables::Railtie < Rails::Railtie
 
   initializer "osom_tables.configure_rails_initialization" do
     ActionController::Base.instance_eval do
-      before_action do
+      before_filter do
         params.delete(:osom_tables_cache_killa)
       end
     end

--- a/lib/osom_tables/railtie.rb
+++ b/lib/osom_tables/railtie.rb
@@ -5,8 +5,8 @@ class OsomTables::Railtie < Rails::Railtie
 
   initializer "osom_tables.configure_rails_initialization" do
     ActionController::Base.instance_eval do
-      before_filter do
-        params.delete(:osom_tables_cache_killa)
+      before_action do
+        params.delete(:osom_tables_cache_killa) if params
       end
     end
   end

--- a/lib/osom_tables/record_tag_helper.rb
+++ b/lib/osom_tables/record_tag_helper.rb
@@ -1,0 +1,107 @@
+#borrow from https://github.com/rails/record_tag_helper/blob/master/record_tag_helper
+
+require 'action_view/record_identifier'
+
+module OsomTables
+  module RecordTagHelper
+    include ActionView::RecordIdentifier
+
+    # Produces a wrapper DIV element with id and class parameters that
+    # relate to the specified Active Record object. Usage example:
+    #
+    #    <%= div_for(@person, class: "foo") do %>
+    #       <%= @person.name %>
+    #    <% end %>
+    #
+    # produces:
+    #
+    #    <div id="person_123" class="person foo"> Joe Bloggs </div>
+    #
+    # You can also pass an array of Active Record objects, which will then
+    # get iterated over and yield each record as an argument for the block.
+    # For example:
+    #
+    #    <%= div_for(@people, class: "foo") do |person| %>
+    #      <%= person.name %>
+    #    <% end %>
+    #
+    # produces:
+    #
+    #    <div id="person_123" class="person foo"> Joe Bloggs </div>
+    #    <div id="person_124" class="person foo"> Jane Bloggs </div>
+    #
+    def div_for(record, *args, &block)
+      content_tag_for(:div, record, *args, &block)
+    end
+
+    # content_tag_for creates an HTML element with id and class parameters
+    # that relate to the specified Active Record object. For example:
+    #
+    #    <%= content_tag_for(:tr, @person) do %>
+    #      <td><%= @person.first_name %></td>
+    #      <td><%= @person.last_name %></td>
+    #    <% end %>
+    #
+    # would produce the following HTML (assuming @person is an instance of
+    # a Person object, with an id value of 123):
+    #
+    #    <tr id="person_123" class="person">....</tr>
+    #
+    # If you require the HTML id attribute to have a prefix, you can specify it:
+    #
+    #    <%= content_tag_for(:tr, @person, :foo) do %> ...
+    #
+    # produces:
+    #
+    #    <tr id="foo_person_123" class="person">...
+    #
+    # You can also pass an array of objects which this method will loop through
+    # and yield the current object to the supplied block, reducing the need for
+    # having to iterate through the object (using <tt>each</tt>) beforehand.
+    # For example (assuming @people is an array of Person objects):
+    #
+    #    <%= content_tag_for(:tr, @people) do |person| %>
+    #      <td><%= person.first_name %></td>
+    #      <td><%= person.last_name %></td>
+    #    <% end %>
+    #
+    # produces:
+    #
+    #    <tr id="person_123" class="person">...</tr>
+    #    <tr id="person_124" class="person">...</tr>
+    #
+    # content_tag_for also accepts a hash of options, which will be converted to
+    # additional HTML attributes. If you specify a <tt>:class</tt> value, it will be combined
+    # with the default class name for your object. For example:
+    #
+    #    <%= content_tag_for(:li, @person, class: "bar") %>...
+    #
+    # produces:
+    #
+    #    <li id="person_123" class="person bar">...
+    #
+    def content_tag_for(tag_name, single_or_multiple_records, prefix = nil, options = nil, &block)
+      options, prefix = prefix, nil if prefix.is_a?(Hash)
+
+      Array(single_or_multiple_records).map do |single_record|
+        content_tag_for_single_record(tag_name, single_record, prefix, options, &block)
+      end.join("\n").html_safe
+    end
+
+    private
+
+    # Called by <tt>content_tag_for</tt> internally to render a content tag
+    # for each record.
+    def content_tag_for_single_record(tag_name, record, prefix, options, &block)
+      options = options ? options.dup : {}
+      options[:class] = [ dom_class(record, prefix), options[:class] ].compact
+      options[:id]    = dom_id(record, prefix)
+
+      if block_given?
+        content_tag(tag_name, capture(record, &block), options)
+      else
+        content_tag(tag_name, "", options)
+      end
+    end
+  end
+end

--- a/osom-tables.gemspec
+++ b/osom-tables.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
+
+  spec.add_dependency 'actionview'
 end

--- a/osom-tables.gemspec
+++ b/osom-tables.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
 
-  spec.add_dependency 'actionview'
+  s.add_dependency 'actionview', '> 5'
 end

--- a/osom-tables.gemspec
+++ b/osom-tables.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
+
+  s.add_dependency 'actionview', '> 5'
 end

--- a/osom-tables.gemspec
+++ b/osom-tables.gemspec
@@ -16,6 +16,4 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
-
-  s.add_dependency 'actionview', '> 5'
 end


### PR DESCRIPTION
`content_tag_for` methods removed from Rails and reintroduced in https://github.com/rails/record_tag_helper 

However, record_tag_helper does not run on Rails 6, so I will move `content_tag_for` to this osom-table 

