### PR TITLE
[NEP-14971] fix head repeat issue again

### DIFF
--- a/app/assets/javascripts/osom-tables.js
+++ b/app/assets/javascripts/osom-tables.js
@@ -150,14 +150,14 @@
 
   // Callback for successful ajax load of table data
   function table_load_success(container, new_content, url) {
-    var new_container = $(new_content);
-    container.html($(new_content).children());
-
-    var actual_table = new_container.find('table');
-    actual_table.data('url', url);
-
-    if (new_container.find('tbody').children().length > 0) {
+    const parser = new DOMParser();
+    const new_content_doc = parser.parseFromString(new_content, "text/html");
+    container.html('<div class="osom-table ">' +  new_content_doc.getElementsByClassName('osom-table')[0].innerHTML + '</div>');
+    var actual_table = container.find('table');
+    if (actual_table.find('tbody').children().length > 0) {
       container.removeClass('empty');
+    } else {
+      container.addClass('empty');
     }
   }
 

--- a/app/assets/javascripts/osom-tables.js
+++ b/app/assets/javascripts/osom-tables.js
@@ -152,7 +152,7 @@
   function table_load_success(container, new_content, url) {
     const parser = new DOMParser();
     const new_content_doc = parser.parseFromString(new_content, "text/html");
-    container.html('<div class="osom-table ">' +  new_content_doc.getElementsByClassName('osom-table')[0].innerHTML + '</div>');
+    container.html(new_content_doc.getElementsByClassName('osom-table')[0].innerHTML);
     var actual_table = container.find('table');
     if (actual_table.find('tbody').children().length > 0) {
       container.removeClass('empty');

--- a/lib/osom_tables.rb
+++ b/lib/osom_tables.rb
@@ -1,3 +1,3 @@
 module OsomTables
-  VERSION = '3.2.2'
+  VERSION = '3.2.3'
 end


### PR DESCRIPTION
We see header repeat issue and fixed in this PR https://github.com/jobready/osom-tables/pull/13 several years ago. 
but the fix itself has a new bug, which case  `osom-table` div keeps increasing, so it was reverted in this PR https://github.com/jobready/osom-tables/pull/15

To fix the header repeat issue, we add code in server controller side to decide send the whole `index` or only `table` content back, like this: `render partial: 'table', layout: false if pagination_request?`
but this server-side solution still has problems:
1 if  the UI add sort function, the sort request and pagination request shoud all return only `table`
2 if the user clicks the page2, and clicks `back` button, it will show the issue again, see this test failed case:
  https://jobready.atlassian.net/browse/NEP-14788?focusedCommentId=325290

To fix it perfectly, We still need to update the javascript code, extract only the content of the div `osom-table` and replace it in the UI.